### PR TITLE
Add the kubernetes agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,43 @@
 pipeline {
-    agent any
+  agent {
+    kubernetes {
+      yaml """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: testcontainers
+spec:
+  containers:
+  - name: jnlp
+    image: jenkins/inbound-agent:latest
+    args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
+  - name: docker
+    image: docker:24.0.2-dind
+    securityContext:
+      privileged: true
+    env:
+    - name: DOCKER_TLS_CERTDIR
+      value: ""
+    ports:
+    - containerPort: 2375
+      name: docker
+    volumeMounts:
+    - name: docker-graph-storage
+      mountPath: /var/lib/docker
+  volumes:
+  - name: docker-graph-storage
+    emptyDir: {}
+"""
+      defaultContainer 'jnlp'
+    }
+  }
 
     tools {
         maven 'maven-3.8.7'
         jdk 'jdk-21.0.7'
         nodejs 'nodejs-20.18.3'
+        /*dockerTool 'docker'*/
     }
 
     environment {


### PR DESCRIPTION
## Summary by Sourcery

Switch the Jenkins pipeline to use a Kubernetes-based agent with custom pod spec for builds

Enhancements:
- Set the default container to 'jnlp' for build commands

CI:
- Replace the generic agent with a Kubernetes agent and embed the pod YAML definition
- Configure a Docker-in-Docker container within the pod including privileged mode, port mapping, and storage volume

Chores:
- Comment out the legacy dockerTool configuration